### PR TITLE
included port number in config/save!'s conn url

### DIFF
--- a/src/yuggoth/config.clj
+++ b/src/yuggoth/config.clj
@@ -54,7 +54,7 @@
 
 (defn save! [config]
   (with-open [con (DriverManager/getConnection
-                    (str "jdbc:postgresql://" (:host config) "/" (:schema config)) (:user config) (:pass config))])
+                    (str "jdbc:postgresql://" (:host config) ":" (:port config) "/" (:schema config)) (:user config) (:pass config))])
   (with-open [w (clojure.java.io/writer (load-config-file))]
     (.write w (str config))
     (reset-config! config)))


### PR DESCRIPTION
It refused connections when the postgresql server was in a different port than 5432
